### PR TITLE
Add padding to show container div

### DIFF
--- a/app/views/journeys/show.html.erb
+++ b/app/views/journeys/show.html.erb
@@ -1,4 +1,4 @@
-<div class="show-container">
+<div class="show-container pb-3">
   <div class="d-flex px-3 pt-5">
     <%= link_to image_tag("go_back_icon.svg"), :back %>
     <div>


### PR DESCRIPTION
## Space below sightseeing list

- Added some padding to the show container div to create some spacing under the sightseeing list

## Tophat 🎩 

- Load a show page and scroll down