### PR TITLE
Fix the navbar postion to keep the layout the same

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -4,7 +4,6 @@
   bottom: 0;
   width: 100%;
   height:70px;
-  margin-bottom: 3px;
 }
 
 .navbar-lewagon .navbar-collapse {
@@ -20,6 +19,7 @@
   width: 100%;
   display: flex;
   justify-content: space-between;
+
   img {
     height: 40px;
   }

--- a/app/assets/stylesheets/pages/_show.scss
+++ b/app/assets/stylesheets/pages/_show.scss
@@ -1,6 +1,7 @@
 .show-container {
   background: $peach-gradient;
   margin-top: 0;
+  min-height: 100vh;
 
   .container-basic-info-icon {
     margin: 0.5rem 30px;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,9 +12,11 @@
   </head>
 
   <body>
-    <p class="notice m-0 flash-padding-fix"><%= notice %></p>
-    <p class="alert m-0 flash-padding-fix"><%= alert %></p>
-    <%= yield %>
+    <div style="min-height:100vh;">
+      <p class="notice m-0 flash-padding-fix"><%= notice %></p>
+      <p class="alert m-0 flash-padding-fix"><%= alert %></p>
+      <%= yield %>
+    </div>
     <%= render "/components/navbar" %>
   </body>
 </html>


### PR DESCRIPTION
## Layout for show and profile page navbar fix

- Navbar now sticks to the bottom but keeps its place in the DOM

## Tophat 🎩 

- Load up the show page and play with the dropdowns
- Load up the profile page and you should see the navbar in the bottom